### PR TITLE
fix(docs): fix CONTRIBUTING.md rendering and restrict direct push to dev

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -2,19 +2,23 @@
 
 ## Branch
 
+```
 prod                            # production-ready only
 dev                             # integration branch
 feature/<issue-number>-<slug>   # new feature
 fix/<issue-number>-<slug>       # bug fix
 refactor/<issue-number>-<slug>  # refactoring only
 chore/<slug>                    # build, deps, config
+```
 
 - slug: lowercase kebab-case (e.g. add-login-api)
-- No direct push to prod, PR only
+- No direct push to `prod` or `dev`, PR only
 
 ## Commit
 
+```
 <type>(<scope>): <subject>
+```
 
 Types: feat | fix | refactor | chore | docs | style
 


### PR DESCRIPTION
## Summary

- 꺾쇠 괄호(`<>`)가 HTML 태그로 파싱되던 Branch 섹션, Commit 포맷을 fenced code block으로 수정
- 브랜치 규칙에 `dev`도 직접 push 금지(`No direct push to prod or dev, PR only`) 추가

Closes #2