### PR TITLE
docs: add issue creation rules to CONTRIBUTING.md

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -8,6 +8,7 @@ dev                             # integration branch
 feature/<issue-number>-<slug>   # new feature
 fix/<issue-number>-<slug>       # bug fix
 refactor/<issue-number>-<slug>  # refactoring only
+docs/<issue-number>-<slug>      # documentation
 chore/<slug>                    # build, deps, config
 ```
 
@@ -35,6 +36,27 @@ Scopes:
 - Start with lowercase verb: add, remove, update, fix
 - No period at end, under 50 chars
 - Add body when the reason for the change is not obvious
+
+## Issue
+
+### Title
+
+```
+[type] short description
+```
+
+Types: bug | feature | refactor | docs | chore
+
+Examples:
+- `[bug] gateway CircuitBreaker duplicate code`
+- `[feature] add file upload API`
+- `[refactor] extract common resilience4j config`
+
+### Rules
+
+- Create an issue before starting any work
+- Reference the issue number in the branch name and commit message
+- Link the issue in the PR body with `Closes #<issue-number>`
 
 ## Pull Request
 


### PR DESCRIPTION
## Summary

- Issue 섹션 추가: 제목 포맷(`[type] short description`), 타입 목록, 작업 규칙
- Branch 섹션에 `docs/<issue-number>-<slug>` 타입 추가 (기존 docs 커밋 타입과 통일)

Closes #5