### PR TITLE
docs: reorder and number sections in CONTRIBUTING.md

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,6 +1,27 @@
 # Git Convention
 
-## Branch
+## 1. Issue
+
+### Title
+
+```
+[type] short description
+```
+
+Types: bug | feature | refactor | docs | chore
+
+Examples:
+- `[bug] gateway CircuitBreaker duplicate code`
+- `[feature] add file upload API`
+- `[refactor] extract common resilience4j config`
+
+### Rules
+
+- Create an issue before starting any work
+- Reference the issue number in the branch name and commit message
+- Link the issue in the PR body with `Closes #<issue-number>`
+
+## 2. Branch
 
 ```
 prod                            # production-ready only
@@ -15,7 +36,7 @@ chore/<slug>                    # build, deps, config
 - slug: lowercase kebab-case (e.g. add-login-api)
 - No direct push to `prod` or `dev`, PR only
 
-## Commit
+## 3. Commit
 
 ```
 <type>(<scope>): <subject>
@@ -37,28 +58,7 @@ Scopes:
 - No period at end, under 50 chars
 - Add body when the reason for the change is not obvious
 
-## Issue
-
-### Title
-
-```
-[type] short description
-```
-
-Types: bug | feature | refactor | docs | chore
-
-Examples:
-- `[bug] gateway CircuitBreaker duplicate code`
-- `[feature] add file upload API`
-- `[refactor] extract common resilience4j config`
-
-### Rules
-
-- Create an issue before starting any work
-- Reference the issue number in the branch name and commit message
-- Link the issue in the PR body with `Closes #<issue-number>`
-
-## Pull Request
+## 4. Pull Request
 
 - Title: same format as commit message
 - One PR = one purpose


### PR DESCRIPTION
## Summary
- Moves Issue section to the top (section 1) so it appears before Branch
- Numbers all sections (1. Issue, 2. Branch, 3. Commit, 4. Pull Request) for clarity

Closes #7