### PR TITLE
chore: add claude code flow command definition

### DIFF
--- a/.claude/commands/flow.md
+++ b/.claude/commands/flow.md
@@ -1,0 +1,13 @@
+Run the full git workflow end-to-end by inferring everything from the current working tree. Do not ask the user any questions.
+
+**Language rules:**
+- All code, file names, commit messages, branch names, and PR titles must be written in **English**.
+- GitHub issue body and PR body must be written in **Korean**.
+
+1. Run `git diff HEAD` and `git status` to understand what changed and why.
+2. From the diff, infer: issue type (`bug | feature | refactor | docs | chore`), a concise issue title, the appropriate branch prefix and slug, the commit type and scope (`member | auth | gateway | eureka | common`), and a commit subject (lowercase verb, under 50 chars). Follow the conventions in CONTRIBUTING.md.
+3. Create a GitHub issue with `gh issue create --title "[type] title" --body "..."`. The title is in English; the body is written in Korean and summarizes what the issue is about. Note the issue number.
+4. Run `git checkout dev && git pull origin dev && git checkout -b <prefix>/<issue-number>-<slug>`.
+5. Stage all changes with `git add .` and commit. Include `Closes #<issue-number>` in the commit body.
+6. Push with `git push -u origin <branch>`.
+7. Create a PR to `dev` with `gh pr create`. The PR title is in English (same format as the commit message). The PR body is written in Korean and includes a summary of changes and `Closes #<issue-number>`. Print the PR URL.


### PR DESCRIPTION
## 변경 내용
- `.claude/commands/flow.md` 추가: `/flow` 커스텀 커맨드 정의
  - git 워크플로우(이슈 생성 → 브랜치 → 커밋 → 푸시 → PR) 자동화
  - 언어 규칙 명시: 코드/커밋/PR 제목은 영어, 이슈/PR 본문은 한국어

## 참고
- `settings.local.json`은 `.gitignore` 적용 대상이므로 커밋에서 제외됨

Closes #9